### PR TITLE
Finish the support for numerical font-weight values that aren't a multiple of 100

### DIFF
--- a/lib/resolveFontWeight.js
+++ b/lib/resolveFontWeight.js
@@ -31,15 +31,25 @@ function resolveFontWeight(desiredWeight, availableWeights) {
   let searchOrder;
 
   if (desiredWeight > 500) {
-    // If the desired weight is greater than 500, weights above the desired weight are checked
-    // in ascending order followed by weights below the desired weight in descending order
+    // If the desired weight is greater than 500, weights greater than or equal to the desired weight
+    // are checked in ascending order followed by weights below the desired weight in descending order
     // until a match is found.
     searchOrder = [...above, ...below.reverse()];
-  } else {
-    // If the desired weight is less than 400, weights below the desired weight are checked
-    // in descending order followed by weights above the desired weight in ascending order
+  } else if (desiredWeight < 400) {
+    // If the desired weight is less than 400, weights less than or equal to the desired weight
+    // are checked in descending order followed by weights above the desired weight in ascending order
     // until a match is found.
     searchOrder = [...below.reverse(), ...above];
+  } else {
+    // If the desired weight is inclusively between 400 and 500, weights greater than or equal to
+    // the target weight are checked in ascending order until 500 is hit and checked, followed
+    // by weights less than the target weight in descending order, followed by weights greater
+    // than 500, until a match is found.
+    searchOrder = [
+      ...above.filter(weight => weight <= 500),
+      ...below.reverse(),
+      ...above.filter(weight => weight > 500)
+    ];
   }
 
   return searchOrder[0];

--- a/test/fontSnapper.js
+++ b/test/fontSnapper.js
@@ -954,6 +954,129 @@ describe('fontSnapper', function() {
         expect(snapped, 'to satisfy', { 'font-weight': '100 800' });
       });
     });
+
+    describe('with values that are not multiples of 100', function() {
+      describe('without ranges', function() {
+        it('should prefer an exact match', function() {
+          const snapped = snap(
+            [
+              { 'font-family': 'foo', 'font-weight': '251' },
+              { 'font-family': 'foo', 'font-weight': '252' },
+              { 'font-family': 'foo', 'font-weight': '253' },
+              { 'font-family': 'foo', 'font-weight': '254' }
+            ],
+            {
+              'font-family': 'foo',
+              'font-weight': '253'
+            }
+          );
+
+          expect(snapped, 'to satisfy', { 'font-weight': '253' });
+        });
+
+        // If the desired weight is inclusively between 400 and 500, weights greater than
+        // or equal to the target weight are checked in ascending order until 500 is hit
+        // and checked, followed by weights less than the target weight in descending order,
+        // followed by weights greater than 500, until a match is found.
+        describe('when the desired weight is in the 400...500 range', function() {
+          it('should prefer a higher value even though a closer match lower than the desired weight is available', function() {
+            const snapped = snap(
+              [
+                { 'font-family': 'foo', 'font-weight': '401' },
+                { 'font-family': 'foo', 'font-weight': '450' }
+              ],
+              {
+                'font-family': 'foo',
+                'font-weight': '402'
+              }
+            );
+
+            expect(snapped, 'to satisfy', { 'font-weight': '450' });
+          });
+
+          it('should prefer a lower value less than 400 even though a closer match higher than 500 is available', function() {
+            const snapped = snap(
+              [
+                { 'font-family': 'foo', 'font-weight': '501' },
+                { 'font-family': 'foo', 'font-weight': '200' }
+              ],
+              {
+                'font-family': 'foo',
+                'font-weight': '499'
+              }
+            );
+
+            expect(snapped, 'to satisfy', { 'font-weight': '200' });
+          });
+        });
+
+        describe('when the desired weight is lower than 400', function() {
+          it('should choose the closest match lower than the desired value', function() {
+            const snapped = snap(
+              [
+                { 'font-family': 'foo', 'font-weight': '341' },
+                { 'font-family': 'foo', 'font-weight': '343' },
+                { 'font-family': 'foo', 'font-weight': '342' }
+              ],
+              {
+                'font-family': 'foo',
+                'font-weight': '344'
+              }
+            );
+
+            expect(snapped, 'to satisfy', { 'font-weight': '343' });
+          });
+
+          it('should prefer a lower value even though a closer match higher than the desired weight is available', function() {
+            const snapped = snap(
+              [
+                { 'font-family': 'foo', 'font-weight': '301' },
+                { 'font-family': 'foo', 'font-weight': '350' }
+              ],
+              {
+                'font-family': 'foo',
+                'font-weight': '344'
+              }
+            );
+
+            expect(snapped, 'to satisfy', { 'font-weight': '301' });
+          });
+        });
+
+        describe('when the desired weight is higher than 500', function() {
+          it('should choose the closest match higher than the desired value', function() {
+            const snapped = snap(
+              [
+                { 'font-family': 'foo', 'font-weight': '557' },
+                { 'font-family': 'foo', 'font-weight': '556' },
+                { 'font-family': 'foo', 'font-weight': '558' }
+              ],
+              {
+                'font-family': 'foo',
+                'font-weight': '555'
+              }
+            );
+
+            expect(snapped, 'to satisfy', { 'font-weight': '556' });
+          });
+
+          it('should prefer a higher value even though a closer match higher than the desired weight is available', function() {
+            const snapped = snap(
+              [
+                { 'font-family': 'foo', 'font-weight': '557' },
+                { 'font-family': 'foo', 'font-weight': '599' }
+              ],
+              {
+                'font-family': 'foo',
+                'font-weight': '558'
+              }
+            );
+
+            expect(snapped, 'to satisfy', { 'font-weight': '599' });
+          });
+        });
+      });
+    });
   });
 
   // Regression test


### PR DESCRIPTION
Fixes #6

I've tested that this makes #5 work with this hack removed: https://github.com/assetgraph/font-snapper/blob/ae0f4798cad641ebc135dbacb6e06f8262647e9c/test/fuzz.js#L155-L165